### PR TITLE
Fix binary file open for Windows

### DIFF
--- a/main.c
+++ b/main.c
@@ -305,7 +305,7 @@ void link() {
 
 void outputBinary() {
   int file;
-  file = open(outName, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  file = open(outName, O_WRONLY | O_CREAT | O_TRUNC|O_BINARY, 0666);
   write(file, memory+lowest, (highest-lowest)+1);
   close(file);
   }
@@ -325,7 +325,7 @@ void outputElfos() {
   header[3] = size & 0xff;
   header[4] = (exec >> 8) & 0xff;
   header[5] = exec & 0xff;
-  file = open(outName, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  file = open(outName, O_WRONLY | O_CREAT | O_TRUNC|O_BINARY, 0666);
   write(file, header, 6);
   write(file, memory+lowest, (highest-lowest)+1);
   close(file);


### PR DESCRIPTION
I missed adding the O_BINARY parameter to the binary file open statements for Windows.  This pull request fixes the binary file open so they correctly write binary files in Windows.