### PR TITLE
Added missing %s argument, token, to printf

### DIFF
--- a/main.c
+++ b/main.c
@@ -284,7 +284,7 @@ int loadFile(char* filename) {
             if (requireAdded[i] == 'N' && strcmp(requires[i], token) == 0) {
               loadModule = -1;
               requireAdded[i] = 'Y';
-              printf("Linking %s from library\n");
+              printf("Linking %s from library\n", token);
               }
           }
         }


### PR DESCRIPTION
Line 287 gave a warning that the %s in printf had no matching argument.  Added the missing argument token to the printf statement.