### PR TITLE
Update Header so LIBPATH is defined differently for Windows

### DIFF
--- a/header.h
+++ b/header.h
@@ -10,9 +10,11 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define LIBPATH     "C:\\Users\\Public\\Series02\\"
 #else
 #include <unistd.h>
 #define O_BINARY 0
+#define LIBPATH        "/usr/local/lib/"
 #endif
 
 #ifdef MAIN
@@ -27,7 +29,7 @@
 #define BM_RCS         4
 #define BM_INTEL       5
 
-#define LIBPATH        "/usr/local/lib/"
+
 
 typedef unsigned char byte;
 typedef unsigned short word;


### PR DESCRIPTION
Moved the LIBPATH variable in the header.h file so that is defined with one path for Linux and another path for Windows.